### PR TITLE
[Feature/SH-01] 카카오 로그인 구현

### DIFF
--- a/explorer-common/src/main/java/com/CPGroupH/error/code/AuthErrorCode.java
+++ b/explorer-common/src/main/java/com/CPGroupH/error/code/AuthErrorCode.java
@@ -23,7 +23,10 @@ public enum AuthErrorCode implements ErrorCode {
     UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "AUTH-009", "토큰의 특정 헤더나 클레임이 지원되지 않습니다."),
 
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-010", "쿠키에 리프레시 토큰이 없습니다."),
-    ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-011", "요청 헤더에 엑세스 토큰이 없습니다.");
+    ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-011", "요청 헤더에 엑세스 토큰이 없습니다."),
+
+    //권한 에러
+    USER_NOT_EXIST(HttpStatus.UNAUTHORIZED, "AUTH_012", "가입한 사용자가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/explorer-common/src/main/java/com/CPGroupH/error/code/AuthErrorCode.java
+++ b/explorer-common/src/main/java/com/CPGroupH/error/code/AuthErrorCode.java
@@ -1,0 +1,31 @@
+package com.CPGroupH.error.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    //
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH-001", "사용자 인증에 실패하였습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH-002", "접근이 거부되었습니다. 이 리소스에 대한 권한이 없습니다."),
+    INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, "AUTH-003", "작업을 수행할 권한이 부족합니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH-004", "로그인에 실패했습니다."),
+
+    //토큰 관련 에러
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH-005", "엑세스 토큰의 유효기간이 만료되었습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH-005", "리프레시 토큰의 유효기간이 만료되었습니다."),
+    TERMS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH-006", "약관 동의 토큰의 유효기간이 만료되었습니다."),
+    INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "AUTH-007", "잘못된 토큰 형식입니다."),
+    INVALID_TOKEN_SIGNATURE(HttpStatus.BAD_REQUEST, "AUTH-008", "토큰의 서명이 일치하지 않습니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "AUTH-009", "토큰의 특정 헤더나 클레임이 지원되지 않습니다."),
+
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-010", "쿠키에 리프레시 토큰이 없습니다."),
+    ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-011", "요청 헤더에 엑세스 토큰이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/explorer-common/src/main/java/com/CPGroupH/error/code/CommonErrorCode.java
+++ b/explorer-common/src/main/java/com/CPGroupH/error/code/CommonErrorCode.java
@@ -1,0 +1,18 @@
+package com.CPGroupH.error.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+    // 서버 및 시스템 관련 에러
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYS-001", "서버 내부 오류가 발생했습니다. 다시 시도해주세요."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "SYS-002", "현재 서비스 이용이 불가능합니다. 나중에 다시 시도해주세요."),
+    GATEWAY_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "SYS-003", "요청 시간이 초과되었습니다. 다시 시도해주세요."),;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/explorer-common/src/main/java/com/CPGroupH/response/BaseResponse.java
+++ b/explorer-common/src/main/java/com/CPGroupH/response/BaseResponse.java
@@ -1,0 +1,18 @@
+package com.CPGroupH.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseResponse {
+    @JsonProperty("isSuccess")
+    @Schema(description = "요청이 성공했는지 여부", example = "true")
+    Boolean isSuccess;
+
+    @JsonProperty("message")
+    @Schema(description = "추가 정보를 제공하는 메시지", example = "요청이 성공적으로 처리되었습니다.")
+    String message;
+}
+

--- a/explorer-common/src/main/java/com/CPGroupH/response/ErrorResponse.java
+++ b/explorer-common/src/main/java/com/CPGroupH/response/ErrorResponse.java
@@ -1,0 +1,26 @@
+package com.CPGroupH.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({"isSuccess", "code", "message", "errors"})
+public class ErrorResponse extends BaseResponse {
+    @Schema(name = "에러 코드")
+    private final String code;
+
+    @Schema(name = "에러 필드 목록")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationError> errors;
+
+    @Builder
+    private ErrorResponse(String code, String message, List<ValidationError> errors) {
+        super(false, message);
+        this.code = code;
+        this.errors = errors;
+    }
+}

--- a/explorer-common/src/main/java/com/CPGroupH/response/ResponseFactory.java
+++ b/explorer-common/src/main/java/com/CPGroupH/response/ResponseFactory.java
@@ -1,0 +1,56 @@
+package com.CPGroupH.response;
+
+import com.CPGroupH.error.code.ErrorCode;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseFactory {
+
+    private static final String SUCCESS_MESSAGE = "요청이 성공적으로 처리되었습니다.";
+    private static final String CREATED_MESSAGE = "리소스가 성공적으로 생성되었습니다.";
+
+    private ResponseFactory() {
+        throw new UnsupportedOperationException("팩토리 유틸리티 메소드는 인스턴스화 할 수 없습니다.");
+    }
+
+    public static <T> ResponseEntity<SuccessResponse<T>> success(T data) {
+        return buildSuccessResponse(SUCCESS_MESSAGE, HttpStatus.OK, data);
+    }
+
+    public static <T> ResponseEntity<SuccessResponse<T>> created(T data) {
+        return buildSuccessResponse(CREATED_MESSAGE, HttpStatus.CREATED, data);
+    }
+
+    public static ResponseEntity<Void> noContent() {
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    private static <T> ResponseEntity<SuccessResponse<T>> buildSuccessResponse(String message, HttpStatus statusCode,
+                                                                               T data) {
+        SuccessResponse<T> successResponse = SuccessResponse.<T>builder()
+                .isSuccess(true)
+                .message(message)
+                .data(data)
+                .build();
+        return new ResponseEntity<>(successResponse, statusCode);
+    }
+
+    // ErrorResponse 생성 메서드
+    public static ResponseEntity<Object> failure(ErrorCode errorCode) {
+        return buildErrorResponse(errorCode, null);
+    }
+
+    public static ResponseEntity<Object> failure(ErrorCode errorCode, List<ValidationError> errors) {
+        return buildErrorResponse(errorCode, errors);
+    }
+
+    private static ResponseEntity<Object> buildErrorResponse(ErrorCode errorCode, List<ValidationError> errors) {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .errors(errors)
+                .build();
+        return new ResponseEntity<>(errorResponse, errorCode.getHttpStatus());
+    }
+}

--- a/explorer-common/src/main/java/com/CPGroupH/response/SuccessResponse.java
+++ b/explorer-common/src/main/java/com/CPGroupH/response/SuccessResponse.java
@@ -1,0 +1,21 @@
+package com.CPGroupH.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({"isSuccess", "message", "data"})
+@Schema(description = "성공 응답")
+public class SuccessResponse<T> extends BaseResponse {
+    @Schema(description = "응답 데이터")
+    private final T data;
+
+    @Builder(access = AccessLevel.PROTECTED)
+    private SuccessResponse(Boolean isSuccess, String message, T data) {
+        super(isSuccess, message);
+        this.data = data;
+    }
+}

--- a/explorer-common/src/main/java/com/CPGroupH/response/ValidationError.java
+++ b/explorer-common/src/main/java/com/CPGroupH/response/ValidationError.java
@@ -1,0 +1,12 @@
+package com.CPGroupH.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ValidationError {
+    private String field;
+    private String message;
+}
+

--- a/explorer-domain/src/main/java/com/CPGroupH/domains/member/entity/Member.java
+++ b/explorer-domain/src/main/java/com/CPGroupH/domains/member/entity/Member.java
@@ -27,10 +27,14 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String nickname;
+
     @Column(nullable = false, length = 255)
     private String email;
 
-    private String profileUrl;
+    private String profileImage;
+
+    private Boolean allowance;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 10)
@@ -40,9 +44,11 @@ public class Member extends BaseEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    public Member(String email, String profileUrl, MemberRole role) {
+    public Member(String nickname, String email, String profileImage, Boolean allowance, MemberRole role) {
+        this.nickname = nickname;
         this.email = email;
-        this.profileUrl = profileUrl;
+        this.profileImage = profileImage;
+        this.allowance = allowance;
         this.role = role;
     }
 

--- a/explorer-domain/src/main/java/com/CPGroupH/domains/member/entity/Member.java
+++ b/explorer-domain/src/main/java/com/CPGroupH/domains/member/entity/Member.java
@@ -56,5 +56,9 @@ public class Member extends BaseEntity {
     public void onDelete() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void updateAllowance() {
+        this.allowance = true;
+    }
 }
 

--- a/explorer-domain/src/main/java/com/CPGroupH/domains/member/repository/MemberRepository.java
+++ b/explorer-domain/src/main/java/com/CPGroupH/domains/member/repository/MemberRepository.java
@@ -1,9 +1,11 @@
 package com.CPGroupH.domains.member.repository;
 
 import com.CPGroupH.domains.member.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
 }

--- a/explorer-external-api/build.gradle
+++ b/explorer-external-api/build.gradle
@@ -5,6 +5,9 @@ plugins {
 }
 
 dependencies {
+    implementation project(":explorer-domain")
+    implementation project(":explorer-common")
+
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // spring
@@ -17,6 +20,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/explorer-external-api/build.gradle
+++ b/explorer-external-api/build.gradle
@@ -7,6 +7,17 @@ plugins {
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // spring
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 

--- a/explorer-external-api/build.gradle
+++ b/explorer-external-api/build.gradle
@@ -5,9 +5,6 @@ plugins {
 }
 
 dependencies {
-    implementation project(":explorer-domain")
-    implementation project(":explorer-common")
-
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // spring
@@ -23,6 +20,10 @@ dependencies {
 
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // mapStruct
+    implementation 'org.mapstruct:mapstruct:1.5.3.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/explorer-external-api/src/main/java/com/CPGroupH/config/RedisConfig.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.CPGroupH.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisProperties.getHost());
+        redisStandaloneConfiguration.setPort(redisProperties.getPort());
+        redisStandaloneConfiguration.setPassword(redisProperties.getPassword());
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/config/SecurityConfig.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/config/SecurityConfig.java
@@ -1,0 +1,120 @@
+package com.CPGroupH.config;
+
+import com.CPGroupH.domains.auth.security.filter.JwtAuthFilter;
+import com.CPGroupH.domains.auth.security.handler.CustomAccessDeniedHandler;
+import com.CPGroupH.domains.auth.security.handler.CustomAuthenticationEntryPoint;
+import com.CPGroupH.domains.auth.security.oauth2.handler.CustomSuccessHandler;
+import com.CPGroupH.domains.auth.security.oauth2.service.CustomOAuth2UserService;
+import com.CPGroupH.domains.auth.security.service.JwtService;
+import com.CPGroupH.domains.auth.security.service.RedisAuthService;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final CustomSuccessHandler customSuccessHandler;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring()
+                .requestMatchers(
+                        new AntPathRequestMatcher("/public/**"),
+                        new AntPathRequestMatcher("/favicon.ico"),
+                        new AntPathRequestMatcher("/swagger-ui/**"),
+                        new AntPathRequestMatcher("/v3/api-docs/**")
+                );
+    }
+
+    //OAuth 인증용 필터체인
+    @Bean
+    public SecurityFilterChain oAuth2SecurityFilterChain(HttpSecurity http) throws Exception {
+        http.securityMatchers(auth -> auth
+                .requestMatchers(
+                        "/oauth2/authorization/**",
+                        "/login/oauth2/code/**")
+                ).cors(corsCustomizer -> corsCustomizer.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService))
+                        .successHandler(customSuccessHandler))
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+
+    //jwt 인증용 필터체인
+    @Bean
+    public SecurityFilterChain jwtSecurityFilterChain(HttpSecurity http, JwtService jwtService,
+                                                      RedisAuthService redisAuthService,
+                                                      CustomAuthenticationEntryPoint customAuthenticationEntryPoint) throws Exception {
+        http
+                .securityMatchers(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/**"
+                        )
+                )
+                .cors(corsCustomizer -> corsCustomizer.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new JwtAuthFilter(jwtService, redisAuthService),
+                        UsernamePasswordAuthenticationFilter.class)
+                .authorizeHttpRequests((auth) -> auth
+                        // 헬스 체크 경로는 jwt 인증 비활성화
+                        .requestMatchers("/api/v1/admin/**")
+                        .permitAll()
+                        .anyRequest()
+                        .authenticated())
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling
+                                .authenticationEntryPoint(customAuthenticationEntryPoint)
+                                .accessDeniedHandler(customAccessDeniedHandler)
+                )
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+
+    //cors
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedOrigins(
+                Arrays.asList(
+                    "http://localhost:8080",
+                    "http://localhost:3000"
+        ));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        configuration.addAllowedHeader("*");
+        configuration.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization"));
+        configuration.setMaxAge(3600L);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/config/WebConfig.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.CPGroupH.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .exposedHeaders("Set-Cookie")
+                .allowedOrigins(
+                        "http://localhost:8080",
+                        "http://localhost:3000");
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/controller/AuthController.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/controller/AuthController.java
@@ -1,7 +1,26 @@
 package com.CPGroupH.domains.auth.controller;
 
+import com.CPGroupH.domains.auth.dto.request.AllowanceRequest;
+import com.CPGroupH.domains.auth.dto.response.AllowanceResponse;
+import com.CPGroupH.domains.auth.dto.response.RefreshResponse;
+import com.CPGroupH.domains.auth.security.oauth2.entity.CustomOAuth2User;
+import com.CPGroupH.domains.auth.security.service.AuthService;
+import com.CPGroupH.domains.auth.security.service.CookieService;
+import com.CPGroupH.domains.auth.security.service.JwtService;
+import com.CPGroupH.response.ResponseFactory;
+import com.CPGroupH.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,5 +28,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
+@Tag(name = "\uD83D\uDD11 인증", description = "Auth API")
 public class AuthController {
+    private final AuthService authService;
+    private final CookieService cookieService;
+    private final JwtService jwtService;
+
+    @Operation(summary = "accessToken 재발급")
+    @PostMapping("/token/reissue")
+    public ResponseEntity<SuccessResponse<RefreshResponse>> reissueToken(
+            HttpServletRequest request
+    ) {
+        String refreshToken = cookieService.getRefreshTokenCookie(request);
+        var result = authService.reissueToken(refreshToken);
+        return ResponseFactory.success(result);
+    }
+
+    @Operation(summary = "설문 조사")
+    @PostMapping("/terms")
+    public ResponseEntity<SuccessResponse<AllowanceResponse>> agreeToTerms(
+            @Valid @RequestBody AllowanceRequest request,
+            HttpServletResponse response
+    ) throws IOException {
+        var result = authService.updateAllowance(request.token());
+        return ResponseFactory.success(result);
+    }
+
+
 }

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/controller/AuthController.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/controller/AuthController.java
@@ -1,0 +1,13 @@
+package com.CPGroupH.domains.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/dto/request/AllowanceRequest.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/dto/request/AllowanceRequest.java
@@ -1,0 +1,14 @@
+package com.CPGroupH.domains.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "설문 참여 요청")
+public record AllowanceRequest(
+        @NotBlank(message = "설문 참여 토큰이 존재하지 않습니다.")
+        @Schema(description = "설문 참여 토큰")
+        String token
+) {
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/dto/response/AllowanceResponse.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/dto/response/AllowanceResponse.java
@@ -1,0 +1,10 @@
+package com.CPGroupH.domains.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AllowanceResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/dto/response/RefreshResponse.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/dto/response/RefreshResponse.java
@@ -1,0 +1,12 @@
+package com.CPGroupH.domains.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "토큰 응답")
+public record RefreshResponse(
+        @Schema(description = "엑세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String accessToken
+) {
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/enums/AuthToken.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/enums/AuthToken.java
@@ -1,0 +1,5 @@
+package com.CPGroupH.domains.auth.enums;
+
+public enum AuthToken {
+    ACCESS_TOKEN,REFRESH_TOKEN, TERMS;
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/mapper/AuthMapper.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/mapper/AuthMapper.java
@@ -1,0 +1,11 @@
+package com.CPGroupH.domains.auth.mapper;
+
+import com.CPGroupH.domains.auth.dto.response.AllowanceResponse;
+import com.CPGroupH.domains.auth.dto.response.RefreshResponse;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface AuthMapper {
+    AllowanceResponse toAllowanceResponse(String accessToken, String refreshToken);
+    RefreshResponse toRefreshResponse(String accessToken);
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/filter/JwtAuthFilter.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/filter/JwtAuthFilter.java
@@ -1,0 +1,70 @@
+package com.CPGroupH.domains.auth.security.filter;
+
+import com.CPGroupH.domains.auth.security.oauth2.entity.CustomOAuth2User;
+import com.CPGroupH.domains.auth.security.oauth2.entity.dto.OAuth2UserDTO;
+import com.CPGroupH.domains.auth.security.service.JwtService;
+import com.CPGroupH.domains.auth.security.service.RedisAuthService;
+import com.CPGroupH.domains.member.entity.Member;
+import com.CPGroupH.error.exception.CustomException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final RedisAuthService redisAuthService;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        Set<String> excludePaths = new HashSet<>(Set.of(
+                "/api/v1/auth/token/reissue",
+                "/api/v1/auth/terms",
+                "/api/v1/dev"
+        ));
+        String requestURI = request.getRequestURI();
+        return excludePaths.stream()
+                .anyMatch(requestURI::startsWith);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            String accessToken = jwtService.resolveAccessToken(request);
+            if (!jwtService.isAccessTokenExpired(accessToken)
+                    && !redisAuthService.isTokenInBlackList(accessToken)
+            ) {
+                Member member = jwtService.getMemberFromAccessToken(accessToken);
+                log.info("[AUTH_INFO] 사용자 인가: ID{} 닉네임{}", member.getId(), member.getNickname());
+                OAuth2UserDTO oauth2UserDTO = OAuth2UserDTO.from(member);
+                CustomOAuth2User customOAuth2User = new CustomOAuth2User(oauth2UserDTO);
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        customOAuth2User,
+                        null,
+                        customOAuth2User.getAuthorities()
+                );
+                SecurityContextHolder.getContext()
+                        .setAuthentication(authentication);
+            }
+        } catch (CustomException ex) {
+            request.setAttribute("error", ex.getErrorCode());
+        } catch (Exception e) {
+            request.setAttribute("error", null);
+        }
+        // 로그인하지 않은 사용자 SecurityContext 에 없으므로 403
+        filterChain.doFilter(request, response);
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/handler/CustomAccessDeniedHandler.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package com.CPGroupH.domains.auth.security.handler;
+
+import com.CPGroupH.error.code.AuthErrorCode;
+import com.CPGroupH.response.ResponseFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
+                       AccessDeniedException e) throws IOException, ServletException {
+
+        ResponseEntity<Object> errorResponse = ResponseFactory.failure(AuthErrorCode.ACCESS_DENIED);
+        httpServletResponse.setContentType("application/json");
+        httpServletResponse.setCharacterEncoding("UTF-8");
+        httpServletResponse.setStatus(errorResponse.getStatusCode()
+                .value());
+        httpServletResponse.getWriter()
+                .write(new ObjectMapper().writeValueAsString(errorResponse.getBody()));
+        httpServletResponse.getWriter()
+                .flush();
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/handler/CustomAuthenticationEntryPoint.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.CPGroupH.domains.auth.security.handler;
+
+import com.CPGroupH.error.code.AuthErrorCode;
+import com.CPGroupH.error.code.ErrorCode;
+import com.CPGroupH.response.ResponseFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        Object errorObj = request.getAttribute("error");
+        ErrorCode errorCode =
+                errorObj instanceof ErrorCode ? (ErrorCode) errorObj : AuthErrorCode.AUTHENTICATION_FAILED;
+        ResponseEntity<Object> errorResponse = ResponseFactory.failure(errorCode);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorResponse.getStatusCode()
+                .value());
+        response.getWriter()
+                .write(new ObjectMapper().writeValueAsString(errorResponse.getBody()));
+        response.getWriter()
+                .flush();
+    }
+}
+

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/entity/CustomOAuth2User.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/entity/CustomOAuth2User.java
@@ -1,0 +1,42 @@
+package com.CPGroupH.domains.auth.security.oauth2.entity;
+
+import com.CPGroupH.domains.auth.security.oauth2.entity.dto.OAuth2UserDTO;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+    private final OAuth2UserDTO oauth2UserDTO;
+
+    @Override
+    public <A> A getAttribute(String name) {
+        return (A) getAttributes().get(name);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Map.of(
+                "nickname", oauth2UserDTO.nickname(),
+                "email", oauth2UserDTO.email(),
+                "profileImage", oauth2UserDTO.profileImage(),
+                "allowance", oauth2UserDTO.allowance()
+        );
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add((GrantedAuthority) () -> oauth2UserDTO.role()
+                .getRoleName());
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return oauth2UserDTO.email();
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/entity/OAuth2Attributes.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/entity/OAuth2Attributes.java
@@ -1,0 +1,40 @@
+package com.CPGroupH.domains.auth.security.oauth2.entity;
+
+import com.CPGroupH.domains.auth.security.oauth2.enums.SocialType;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuth2Attributes {
+    private final Map<String, Object> attributes;
+    private final String email;
+    private final String nickname;
+    private final String profileImage;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private OAuth2Attributes(Map<String, Object> attributes, String email, String nickname, String profileImage) {
+        this.attributes = attributes;
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+
+    public static OAuth2Attributes of(SocialType socialType, Map<String, Object> attributes) {
+        return switch (socialType) {
+            case KAKAO -> ofKakao(attributes);
+        };
+    }
+
+    private static OAuth2Attributes ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, String> profile = (Map<String, String>) kakaoAccount.get("profile");
+        return OAuth2Attributes.builder().
+                email(String.valueOf(kakaoAccount.get("email")))
+                .nickname(profile.get("nickname"))
+                .profileImage(profile.get("profile_image_url"))
+                .build();
+    }
+}
+

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/entity/dto/OAuth2UserDTO.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/entity/dto/OAuth2UserDTO.java
@@ -1,0 +1,26 @@
+package com.CPGroupH.domains.auth.security.oauth2.entity.dto;
+
+import com.CPGroupH.common.enums.MemberRole;
+import com.CPGroupH.domains.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record OAuth2UserDTO(
+        Long memberId,
+        String nickname,
+        String email,
+        String profileImage,
+        Boolean allowance,
+        MemberRole role
+) {
+    public static OAuth2UserDTO from(Member member) {
+        return new OAuth2UserDTO(
+                member.getId(),
+                member.getNickname(),
+                member.getEmail(),
+                member.getProfileImage(),
+                member.getAllowance(),
+                member.getRole()
+        );
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/enums/SocialType.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/enums/SocialType.java
@@ -1,0 +1,27 @@
+package com.CPGroupH.domains.auth.security.oauth2.enums;
+
+import lombok.Getter;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+@Getter
+public enum SocialType {
+    KAKAO("KAKAO", "카카오 로그인");
+
+    private final String registrationId;
+    private final String title;
+
+    SocialType(String registrationId, String title) {
+        this.registrationId = registrationId;
+        this.title = title;
+    }
+
+    public static SocialType from(String registrationId) {
+        for (SocialType socialType : SocialType.values()) {
+            if (socialType.getRegistrationId()
+                    .equals(registrationId)) {
+                return socialType;
+            }
+        }
+        throw new OAuth2AuthenticationException("OAuth2 제공자가 올바르지 않습니다. registrationId: %s".formatted(registrationId));
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/handler/CustomSuccessHandler.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/handler/CustomSuccessHandler.java
@@ -1,0 +1,15 @@
+package com.CPGroupH.domains.auth.security.oauth2.handler;
+
+import com.CPGroupH.domains.auth.security.service.CookieService;
+import com.CPGroupH.domains.auth.security.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtService jwtService;
+    private final CookieService cookieService;
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/service/CustomOAuth2UserService.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,58 @@
+package com.CPGroupH.domains.auth.security.oauth2.service;
+
+import com.CPGroupH.common.enums.MemberRole;
+import com.CPGroupH.domains.auth.security.oauth2.entity.CustomOAuth2User;
+import com.CPGroupH.domains.auth.security.oauth2.enums.SocialType;
+import com.CPGroupH.domains.auth.security.oauth2.entity.OAuth2Attributes;
+import com.CPGroupH.domains.auth.security.oauth2.entity.dto.OAuth2UserDTO;
+import com.CPGroupH.domains.member.entity.Member;
+import com.CPGroupH.domains.member.repository.MemberRepository;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(request);
+
+        // Oauth2 서비스명
+        String registrationId = request.getClientRegistration()
+                .getRegistrationId();
+        // 인증된 사용자 정보
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        // 소셜 로그인 종류
+        SocialType socialType = SocialType.from(registrationId);
+        // 소셜 로그인 attributes
+        OAuth2Attributes oAuth2Attributes = OAuth2Attributes.of(socialType, attributes);
+
+        Member member = memberRepository.findByEmail(oAuth2Attributes.getEmail())
+                .orElseGet(() -> {
+                    // 사용자가 없다면 생성
+                    Member newMember = Member.builder()
+                            .nickname(oAuth2Attributes.getNickname())
+                            .email(oAuth2Attributes.getEmail())
+                            .profileImage(oAuth2Attributes.getProfileImage())
+                            .role(MemberRole.USER)
+                            .allowance(false)
+                            .build();
+
+                    return memberRepository.save(newMember);
+                });
+        OAuth2UserDTO oauth2UserDTO = OAuth2UserDTO.from(member);
+
+        // SecurityContext 에 저장
+        return new CustomOAuth2User(oauth2UserDTO);
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/service/AuthService.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/service/AuthService.java
@@ -1,0 +1,19 @@
+package com.CPGroupH.domains.auth.security.service;
+
+import com.CPGroupH.domains.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+    private final RedisAuthService redisAuthService;
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+
+
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/service/AuthService.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/service/AuthService.java
@@ -1,6 +1,12 @@
 package com.CPGroupH.domains.auth.security.service;
 
+import com.CPGroupH.domains.auth.dto.response.AllowanceResponse;
+import com.CPGroupH.domains.auth.dto.response.RefreshResponse;
+import com.CPGroupH.domains.auth.mapper.AuthMapper;
+import com.CPGroupH.domains.member.entity.Member;
 import com.CPGroupH.domains.member.repository.MemberRepository;
+import com.CPGroupH.error.code.AuthErrorCode;
+import com.CPGroupH.error.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +20,39 @@ public class AuthService {
     private final RedisAuthService redisAuthService;
     private final JwtService jwtService;
     private final MemberRepository memberRepository;
+    private final AuthMapper authMapper;
+
+    public RefreshResponse reissueToken(String refreshToken) {
+        log.info("[AUTH_INFO]refreshToken 을 이용해 accessToken 재발급: {}", refreshToken);
+        // refresh 토큰 만료여부 검사
+        if (jwtService.isRefreshTokenExpired(refreshToken)) {
+            log.info("refreshToken 만료: {}", refreshToken);
+            throw new CustomException(AuthErrorCode.ACCESS_TOKEN_EXPIRED);
+        }
+        Long memberId = jwtService.getMemberIdFromRefreshToken(refreshToken);
+        String redisRefreshToken = redisAuthService.getRefreshToken(memberId);
+        // 유효한 jwt 토큰이라면, 사용자의 refreshToken 과 대조한다.
+        if (redisRefreshToken == null || !redisRefreshToken.equals(refreshToken)) {
+            log.warn("[AUTH_WARN] 사용자의 refreshToken 이 아님: {}", refreshToken);
+            throw new CustomException(AuthErrorCode.ACCESS_DENIED);
+        }
+        String newAccessToken = jwtService.createAccessToken(memberId);
+        return authMapper.toRefreshResponse(newAccessToken);
+    }
 
 
+    @Transactional
+    public AllowanceResponse updateAllowance(String allowanceToken) {
+        if (jwtService.isAllowanceTokenExpired(allowanceToken)) {
+            log.info("약관 동의 토큰 만료: {}", allowanceToken);
+            throw new CustomException(AuthErrorCode.TERMS_TOKEN_EXPIRED);
+        }
+        Member member = jwtService.getMemberFromAllowanceToken(allowanceToken);
+        member.updateAllowance();
+        memberRepository.save(member);
+        Long memberId = member.getId();
+        String accessToken = jwtService.createAccessToken(memberId);
+        String refreshToken = jwtService.createRefreshToken(memberId);
+        return authMapper.toAllowanceResponse(accessToken, refreshToken);
+    }
 }

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/service/CookieService.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/service/CookieService.java
@@ -1,0 +1,77 @@
+package com.CPGroupH.domains.auth.security.service;
+
+import com.CPGroupH.error.code.AuthErrorCode;
+import com.CPGroupH.error.exception.CustomException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CookieService {
+    @Value("${cookie.max-age")
+    private int maxAge;
+
+    @Value("${cookie.domain")
+    private String domain;
+
+    @Value("${cookie.access-name")
+    private String accessName;
+
+    @Value("${cookie.refresh-name")
+    private String refreshName;
+
+    private Cookie createTokenCookie(String cookieName, String cookie){
+        Cookie newCookie = new Cookie(accessName, cookie);
+        newCookie.setMaxAge(maxAge);
+        newCookie.setDomain(domain);
+        newCookie.setPath("/");
+        newCookie.setHttpOnly(false);
+        newCookie.setSecure(true);
+        return newCookie;
+    }
+
+    private void clearTokenCookie(String cookieName, HttpServletResponse response){
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        cookie.setDomain(domain);
+        cookie.setPath("/");
+        cookie.setHttpOnly(false);
+        cookie.setSecure(true);
+        response.addCookie(cookie);
+    }
+
+    public Cookie createAccessTokenCookie(String token) {
+        return createTokenCookie(accessName, token);
+    }
+
+    public Cookie createRefreshTokenCookie(String refreshToken) {
+        return createTokenCookie(refreshName, refreshToken);
+    }
+
+    public void clearAccessAndRefreshCookie(HttpServletResponse response){
+        clearTokenCookie(accessName, response);
+        clearTokenCookie(refreshName, response);
+    }
+
+    public String getRefreshTokenCookie(HttpServletRequest request) {
+        String refreshToken = null;
+        Cookie[] cookies = request.getCookies();
+
+        if(cookies == null || cookies.length == 0){
+            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        for (Cookie cookie : cookies) {
+            if(cookie != null && cookie.getName().equals(refreshName)){
+                refreshToken = cookie.getValue();
+            }
+        }
+        if(refreshToken == null){
+            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        return refreshToken;
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/service/JwtService.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/service/JwtService.java
@@ -1,0 +1,182 @@
+package com.CPGroupH.domains.auth.security.service;
+
+import com.CPGroupH.domains.auth.enums.AuthToken;
+import com.CPGroupH.domains.member.entity.Member;
+import com.CPGroupH.domains.member.repository.MemberRepository;
+import com.CPGroupH.error.code.AuthErrorCode;
+import com.CPGroupH.error.code.CommonErrorCode;
+import com.CPGroupH.error.exception.CustomException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final RedisAuthService redisAuthService;
+    private final MemberRepository memberRepository;
+
+    @Value("${jwt.access.secret}")
+    private String accessTokenSecret;
+
+    @Value("${jwt.access.expires-in}")
+    private long accessTokenExpiresIn;
+
+    @Value("${jwt.refresh.secret}")
+    private String refreshTokenSecret;
+
+    @Value("${jwt.refresh.expires-in}")
+    private long refreshTokenExpiresIn;
+
+    @Value("${jwt.allowance.secret}")
+    private String allowanceSecret;
+
+    @Value("${jwt.allowance.expires-in}")
+    private long allowanceTokenExpiresIn;
+
+    private SecretKey accessTokenSecretKey;
+    private SecretKey refreshTokenSecretKey;
+    private SecretKey allowanceTokenSecretKey;
+
+    @PostConstruct
+    public void init() {
+        accessTokenSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(accessTokenSecret));
+        refreshTokenSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(refreshTokenSecret));
+        allowanceTokenSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(allowanceSecret));
+    }
+
+    public String resolveAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        throw new CustomException(AuthErrorCode.ACCESS_TOKEN_NOT_FOUND);
+    }
+
+    public String createAccessToken(Long memberId) {
+        return createToken(memberId, accessTokenExpiresIn, accessTokenSecretKey);
+    }
+
+    public String createRefreshToken(Long memberId) {
+        String refreshToken = createToken(memberId, refreshTokenExpiresIn, refreshTokenSecretKey);
+        redisAuthService.setRefreshToken(memberId, refreshToken, refreshTokenExpiresIn);
+        return refreshToken;
+    }
+
+    public String createAllowanceToken(Long memberId) {
+        return createToken(memberId, allowanceTokenExpiresIn, allowanceTokenSecretKey);
+    }
+
+    public boolean isAllowanceTokenExpired(String allowanceToken) {
+        return isTokenExpired(allowanceToken, allowanceTokenSecretKey, AuthToken.TERMS);
+    }
+
+    public boolean isRefreshTokenExpired(String refreshToken) {
+        return isTokenExpired(refreshToken, refreshTokenSecretKey, AuthToken.REFRESH_TOKEN);
+    }
+
+    public boolean isAccessTokenExpired(String accessToken) {
+        return isTokenExpired(accessToken, accessTokenSecretKey, AuthToken.ACCESS_TOKEN);
+    }
+
+    public Member getMemberFromAccessToken(String accessToken) {
+        Long memberId = getMemberIdFromAccessToken(accessToken);
+       return memberRepository.findById(memberId).orElseThrow(() -> {
+            return new CustomException(AuthErrorCode.USER_NOT_EXIST);
+        });
+    }
+
+    public Member getMemberFromRefreshToken(String refreshToken) {
+        Long memberId = getMemberIdFromRefreshToken(refreshToken);
+        return memberRepository.findById(memberId).orElseThrow(() -> {
+            return new CustomException(AuthErrorCode.USER_NOT_EXIST);
+        });
+    }
+
+    public Member getMemberFromAllowanceToken(String allowanceToken) {
+        Long memberId = getMemberIdFromAllowanceToken(allowanceToken);
+        return memberRepository.findById(memberId).orElseThrow(() -> {
+            return new CustomException(AuthErrorCode.USER_NOT_EXIST);
+        });
+    }
+
+    public Long getMemberIdFromRefreshToken(String refreshToken) {
+        return parseMemberId(refreshToken, refreshTokenSecretKey);
+    }
+
+    public Long getMemberIdFromAccessToken(String accessToken) {
+        return parseMemberId(accessToken, accessTokenSecretKey);
+    }
+
+    public Long getMemberIdFromAllowanceToken(String allowanceToken) {
+        return parseMemberId(allowanceToken, allowanceTokenSecretKey);
+    }
+
+
+    private Claims getClaimsFromToken(String token, SecretKey secretKey) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    private String createToken(Long memberId, long expiresIn, SecretKey secretKey) {
+        return Jwts.builder()
+                .claim("memberId", memberId)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis()+ expiresIn*1000 ))
+                .signWith(secretKey, SIG.HS256)
+                .compact();
+    }
+
+    private Long parseMemberId(String token, SecretKey secretKey) {
+        return getClaimsFromToken(token, secretKey).get("memberId", Long.class);
+    }
+
+    private boolean isTokenExpired(String token, SecretKey secretKey, AuthToken authToken) {
+        try{
+            return getClaimsFromToken(token, secretKey).getExpiration().before(new Date());
+        }catch (JwtException e) {
+            if(e instanceof ExpiredJwtException) {
+                switch (authToken){
+                    case ACCESS_TOKEN -> throw new CustomException(AuthErrorCode.ACCESS_TOKEN_EXPIRED);
+                    case REFRESH_TOKEN -> throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+                    case TERMS -> throw new CustomException(AuthErrorCode.TERMS_TOKEN_EXPIRED);
+                }
+            }
+            if(e instanceof MalformedJwtException) {
+                throw new CustomException(AuthErrorCode.INVALID_TOKEN_FORMAT);
+            }
+            else if(e instanceof SignatureException) {
+                throw new CustomException(AuthErrorCode.INVALID_TOKEN_SIGNATURE);
+            }
+            else if(e instanceof UnsupportedJwtException){
+                throw new CustomException(AuthErrorCode.UNSUPPORTED_TOKEN);
+            }
+            else{//토큰 검사 중 알 수 없는 오류 발생시
+                throw new CustomException(CommonErrorCode.INTERNAL_SERVER_ERROR);
+            }
+        }
+
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/service/RedisAuthService.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/auth/security/service/RedisAuthService.java
@@ -1,0 +1,44 @@
+package com.CPGroupH.domains.auth.security.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisAuthService {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void setRefreshToken(Long memberId, String value, Long expireTime) {
+        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+        String key = generateRefreshTokenKey(memberId);
+        ops.set(key, value, Duration.ofSeconds(expireTime));
+    }
+
+    public String getRefreshToken(Long memberId) {
+        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+        String key = generateRefreshTokenKey(memberId);
+        return ops.get(key);
+    }
+
+    public void deleteRefreshToken(Long memberId) {
+        String key = generateRefreshTokenKey(memberId);
+        stringRedisTemplate.delete(key);
+    }
+
+    public Boolean isTokenInBlackList(String token) {
+        String key = generateBlackedTokenKey(token);
+        return stringRedisTemplate.hasKey(key);
+    }
+
+    private String generateRefreshTokenKey(Long memberId) {
+        return "auth:refresh:" + memberId;
+    }
+
+    private String generateBlackedTokenKey(String accessToken) {
+        return "auth:blacked:" + accessToken;
+    }
+}
+

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/member/dto/response/MemberResDTO.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/member/dto/response/MemberResDTO.java
@@ -10,7 +10,7 @@ public record MemberResDTO(Long id, String email, String profileUrl, MemberRole 
         return new MemberResDTO(
                 member.getId(),
                 member.getEmail(),
-                member.getProfileUrl(),
+                member.getProfileImage(),
                 member.getRole(),
                 member.getDeletedAt()
         );
@@ -19,7 +19,7 @@ public record MemberResDTO(Long id, String email, String profileUrl, MemberRole 
     public Member toEntity() {
         return Member.builder()
                 .email(this.email)
-                .profileUrl(this.profileUrl)
+                .profileImage(this.profileUrl)
                 .role(this.role)
                 .build();
     }

--- a/explorer-external-api/src/main/resources/application-common.yml
+++ b/explorer-external-api/src/main/resources/application-common.yml
@@ -1,0 +1,10 @@
+jwt:
+  access:
+    secret: 8ed3d8a1f74cf6ba0815e9c58e87d708973907f5218a052ac57e5b3cb13d074b
+    expires-in: 7200
+  refresh:
+    secret: d483f13b53ffb4b4ca45156ea0ffdf32e4cabd4a901556d69d7355ba1f548d52
+    expires-in: 604800
+  allowance:
+    secret: e20b675a52da5aa6d3d181dc69614e38d13ed80fd88c162cdd93047c566cd805
+    expires-in: 900

--- a/explorer-external-api/src/main/resources/application-common.yml
+++ b/explorer-external-api/src/main/resources/application-common.yml
@@ -8,3 +8,18 @@ jwt:
   allowance:
     secret: e20b675a52da5aa6d3d181dc69614e38d13ed80fd88c162cdd93047c566cd805
     expires-in: 900
+
+cookie:
+  expiration: 3600
+  domain: localhost
+  max-age: 300
+  access-name: ac_t
+  refresh-name: rf_t
+
+frontend:
+  auth-redirect-url: http://localhost:3000/loading
+  base-url: http://localhost:3000
+  allowance-redirect-url: http://localhost:3000/login/term
+
+backend:
+  base-url: http://localhost:8080

--- a/explorer-external-api/src/main/resources/application.yml
+++ b/explorer-external-api/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6378
+      password: isshoni7
+      timeout: 2000
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            client-id: 3f60f411225724220d965e0349fa56db
+            client-secret: rKPWKpG7EhTCInvm1VIetR94o7fiwIKp
+            redirect-uri: http://localhost:8080/oauth2/kakao
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+              - profile_image
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+

--- a/explorer-external-api/src/main/resources/application.yml
+++ b/explorer-external-api/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
             scope:
               - profile_nickname
               - profile_image
+              - account_email
 
         provider:
           kakao:


### PR DESCRIPTION
### 1. 작업 내용 간단 요약

소셜 로그인 및 에러 코드 등을 추가하였습니다.

카카오 로그인 밖에 없긴 하지만 추후에 네이버 로그인 등 확장성을 고려하여 구현하였습니다.

그 외에 질문할 내용 있으시면 확인해주세요.