### PR TITLE
[Feature/HB-04]: 채팅 도메인 조회 기능 추가

### DIFF
--- a/explorer-domain/src/main/java/com/CPGroupH/domains/chat/entity/repository/ChatRoomRepository.java
+++ b/explorer-domain/src/main/java/com/CPGroupH/domains/chat/entity/repository/ChatRoomRepository.java
@@ -1,13 +1,20 @@
 package com.CPGroupH.domains.chat.entity.repository;
 
 import com.CPGroupH.domains.chat.entity.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    
+
     Optional<ChatRoom> findChatRoomById(Long id);
+
+    @Query("SELECT cr FROM ChatRoom cr JOIN cr.participants p WHERE p.id = :participantId")
+    Page<ChatRoom> findByParticipantId(@Param("participantId") Long participantId, Pageable pageable);
 }

--- a/explorer-domain/src/main/java/com/CPGroupH/domains/chat/entity/repository/ChatRoomRepository.java
+++ b/explorer-domain/src/main/java/com/CPGroupH/domains/chat/entity/repository/ChatRoomRepository.java
@@ -4,6 +4,10 @@ import com.CPGroupH.domains.chat.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    
+    Optional<ChatRoom> findChatRoomById(Long id);
 }

--- a/explorer-domain/src/main/java/com/CPGroupH/domains/chat/entity/repository/MessageRepository.java
+++ b/explorer-domain/src/main/java/com/CPGroupH/domains/chat/entity/repository/MessageRepository.java
@@ -1,10 +1,16 @@
 package com.CPGroupH.domains.chat.entity.repository;
 
 import com.CPGroupH.domains.chat.entity.Message;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
-    
+    @Query("SELECT m FROM Message m WHERE m.chatRoom.id = :chatRoomId")
+    Page<Message> findByChatRoomId(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
+
 }

--- a/explorer-domain/src/main/java/com/CPGroupH/domains/common/entity/BaseEntity.java
+++ b/explorer-domain/src/main/java/com/CPGroupH/domains/common/entity/BaseEntity.java
@@ -1,14 +1,17 @@
 package com.CPGroupH.domains.common.entity;
 
 import jakarta.persistence.EntityListeners;
-import java.time.LocalDateTime;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
+
 @Getter
 @EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
 public abstract class BaseEntity {
     @CreatedDate
     private LocalDateTime createdAt;

--- a/explorer-domain/src/main/resources/application-domain-local.yml
+++ b/explorer-domain/src/main/resources/application-domain-local.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/grouph
+    url: jdbc:mysql://localhost:3307/grouph
     username: root
     password: cloudproject11
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/explorer-external-api/build.gradle
+++ b/explorer-external-api/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/controller/ChatRoomController.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/controller/ChatRoomController.java
@@ -30,11 +30,12 @@ public class ChatRoomController {
     @Operation(summary = "채팅방 가져오기")
     @GetMapping("/")
     public ResponseEntity<SuccessResponse<Page<ChatRoom>>> getChatRooms(@RequestParam(value = "participantId", required = false) Long participantId,
+                                                                        @RequestParam(value = "page", defaultValue = "0", required = false) Integer page,
                                                                         @RequestParam(value = "limit", required = false) Integer limit,
                                                                         @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
                                                                         @RequestParam(value = "order", defaultValue = "desc") String order) {
 
-        Pageable pageable = PageRequest.of(0, limit != null ? limit : 10,
+        Pageable pageable = PageRequest.of(page, limit != null ? limit : 10,
                 "desc".equalsIgnoreCase(order) ? Sort.by(sort).descending() : Sort.by(sort).ascending());
 
         Page<ChatRoom> chatRooms = participantId != null

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/controller/ChatRoomController.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/controller/ChatRoomController.java
@@ -1,0 +1,46 @@
+package com.CPGroupH.domains.chat.controller;
+
+import com.CPGroupH.domains.chat.entity.ChatRoom;
+import com.CPGroupH.domains.chat.service.ChatRoomService;
+import com.CPGroupH.response.ResponseFactory;
+import com.CPGroupH.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chatrooms")
+@Tag(name = "ChatRoom", description = "ChatRoom API")
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @Operation(summary = "채팅방 가져오기")
+    @GetMapping("/")
+    public ResponseEntity<SuccessResponse<Page<ChatRoom>>> getChatRooms(@RequestParam(value = "participantId", required = false) Long participantId,
+                                                                        @RequestParam(value = "limit", required = false) Integer limit,
+                                                                        @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
+                                                                        @RequestParam(value = "order", defaultValue = "desc") String order) {
+
+        Pageable pageable = PageRequest.of(0, limit != null ? limit : 10,
+                "desc".equalsIgnoreCase(order) ? Sort.by(sort).descending() : Sort.by(sort).ascending());
+
+        Page<ChatRoom> chatRooms = participantId != null
+                ? chatRoomService.getChatRoomsByParticipant(participantId, pageable)
+                : chatRoomService.getAllChatRooms(pageable);
+
+        return ResponseFactory.success(chatRooms);
+    }
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/controller/MessageController.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/controller/MessageController.java
@@ -1,0 +1,4 @@
+package com.CPGroupH.domains.chat.controller;
+
+public class MessageController {
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/controller/MessageController.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/controller/MessageController.java
@@ -1,4 +1,47 @@
 package com.CPGroupH.domains.chat.controller;
 
+import com.CPGroupH.domains.chat.entity.Message;
+import com.CPGroupH.domains.chat.service.MessageService;
+import com.CPGroupH.response.ResponseFactory;
+import com.CPGroupH.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/messages")
+@Tag(name = "Message", description = "Message API")
 public class MessageController {
+
+    private final MessageService messageService;
+
+    @Operation(summary = "메세지 가져오기")
+    @GetMapping("/")
+    public ResponseEntity<SuccessResponse<Page<Message>>> getMessages(@RequestParam(value = "chatRoomId") Long chatRoomId,
+                                                                      @RequestParam(value = "page", defaultValue = "0", required = false) Integer page,
+                                                                      @RequestParam(value = "limit", defaultValue = "100", required = false) Integer limit,
+                                                                      @RequestParam(value = "sort", defaultValue = "createdAt") String sort,
+                                                                      @RequestParam(value = "order", defaultValue = "desc") String order) {
+
+        Pageable pageable = PageRequest.of(
+                page,
+                limit,
+                "desc".equalsIgnoreCase(order) ? Sort.by(sort).descending() : Sort.by(sort).ascending()
+        );
+
+        Page<Message> messages = messageService.getMessagesByChatRoomId(chatRoomId, pageable);
+        return ResponseFactory.success(messages);
+    }
 }

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/dto/request/MessageReqDTO.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/dto/request/MessageReqDTO.java
@@ -1,5 +1,6 @@
 package com.CPGroupH.domains.chat.dto.request;
 
+import com.CPGroupH.domains.chat.entity.ChatRoom;
 import com.CPGroupH.domains.chat.entity.Message;
 import com.CPGroupH.domains.member.entity.Member;
 
@@ -11,9 +12,10 @@ public record MessageReqDTO(String sender, String contents) {
 //        );
 //    }
 //
-    public Message toEntity(Member sender) {
+    public Message toEntity(Member sender, ChatRoom chatRoom) {
         return Message.builder()
                 .sender(sender)
+                .chatRoom(chatRoom)
                 .content(this.contents)
                 .build();
     }

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/ChatRoomService.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/ChatRoomService.java
@@ -1,7 +1,13 @@
 package com.CPGroupH.domains.chat.service;
 
 import com.CPGroupH.domains.chat.entity.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ChatRoomService {
     ChatRoom findChatRoomById(String id);
+
+    Page<ChatRoom> getChatRoomsByParticipant(Long participantId, Pageable pageable);
+
+    Page<ChatRoom> getAllChatRooms(Pageable pageable);
 }

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/ChatRoomService.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/ChatRoomService.java
@@ -1,0 +1,7 @@
+package com.CPGroupH.domains.chat.service;
+
+import com.CPGroupH.domains.chat.entity.ChatRoom;
+
+public interface ChatRoomService {
+    ChatRoom findChatRoomById(String id);
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/MessageService.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/MessageService.java
@@ -1,7 +1,11 @@
 package com.CPGroupH.domains.chat.service;
 
 import com.CPGroupH.domains.chat.entity.Message;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface MessageService {
     Message saveMessage(Message message);
+
+    Page<Message> getMessagesByChatRoomId(Long chatRoomId, Pageable pageable);
 }

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/impl/ChatRoomServiceImpl.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/impl/ChatRoomServiceImpl.java
@@ -4,6 +4,9 @@ import com.CPGroupH.domains.chat.entity.ChatRoom;
 import com.CPGroupH.domains.chat.entity.repository.ChatRoomRepository;
 import com.CPGroupH.domains.chat.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
@@ -16,6 +19,22 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     public ChatRoom findChatRoomById(String id) {
         return chatRoomRepository.findChatRoomById(Long.parseLong(id)).orElseThrow(() -> new NoSuchElementException("ChatRoom이 없습니다"));
+    }
+
+    public Page<ChatRoom> getChatRoomsByParticipant(Long participantId, Integer limit) {
+        Pageable pageable = (limit != null && limit > 0)
+                ? PageRequest.of(0, limit)
+                : Pageable.unpaged();
+
+        return chatRoomRepository.findByParticipantId(participantId, pageable);
+    }
+
+    public Page<ChatRoom> getAllChatRooms(Integer limit) {
+        Pageable pageable = (limit != null && limit > 0)
+                ? PageRequest.of(0, limit)
+                : Pageable.unpaged();
+
+        return chatRoomRepository.findAll(pageable);
     }
 
 }

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/impl/ChatRoomServiceImpl.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/impl/ChatRoomServiceImpl.java
@@ -5,7 +5,6 @@ import com.CPGroupH.domains.chat.entity.repository.ChatRoomRepository;
 import com.CPGroupH.domains.chat.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -21,18 +20,12 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         return chatRoomRepository.findChatRoomById(Long.parseLong(id)).orElseThrow(() -> new NoSuchElementException("ChatRoom이 없습니다"));
     }
 
-    public Page<ChatRoom> getChatRoomsByParticipant(Long participantId, Integer limit) {
-        Pageable pageable = (limit != null && limit > 0)
-                ? PageRequest.of(0, limit)
-                : Pageable.unpaged();
+    public Page<ChatRoom> getChatRoomsByParticipant(Long participantId, Pageable pageable) {
 
         return chatRoomRepository.findByParticipantId(participantId, pageable);
     }
 
-    public Page<ChatRoom> getAllChatRooms(Integer limit) {
-        Pageable pageable = (limit != null && limit > 0)
-                ? PageRequest.of(0, limit)
-                : Pageable.unpaged();
+    public Page<ChatRoom> getAllChatRooms(Pageable pageable) {
 
         return chatRoomRepository.findAll(pageable);
     }

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/impl/ChatRoomServiceImpl.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/impl/ChatRoomServiceImpl.java
@@ -1,0 +1,21 @@
+package com.CPGroupH.domains.chat.service.impl;
+
+import com.CPGroupH.domains.chat.entity.ChatRoom;
+import com.CPGroupH.domains.chat.entity.repository.ChatRoomRepository;
+import com.CPGroupH.domains.chat.service.ChatRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomServiceImpl implements ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    public ChatRoom findChatRoomById(String id) {
+        return chatRoomRepository.findChatRoomById(Long.parseLong(id)).orElseThrow(() -> new NoSuchElementException("ChatRoom이 없습니다"));
+    }
+
+}

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/impl/ChatWebSocketServiceImpl.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/impl/ChatWebSocketServiceImpl.java
@@ -1,7 +1,9 @@
 package com.CPGroupH.domains.chat.service.impl;
 
 import com.CPGroupH.domains.chat.dto.request.MessageReqDTO;
+import com.CPGroupH.domains.chat.entity.ChatRoom;
 import com.CPGroupH.domains.chat.entity.Message;
+import com.CPGroupH.domains.chat.service.ChatRoomService;
 import com.CPGroupH.domains.chat.service.ChatWebSocketService;
 import com.CPGroupH.domains.chat.service.MessageService;
 import com.CPGroupH.domains.member.entity.Member;
@@ -17,10 +19,12 @@ public class ChatWebSocketServiceImpl implements ChatWebSocketService {
     private final SimpMessagingTemplate messagingTemplate;
     private final MemberService memberService;
     private final MessageService messageService;
+    private final ChatRoomService chatRoomService;
 
     public void sendMessageToRoom(String chatRoomId, MessageReqDTO chatMessage) {
         Member sender = memberService.findMemberByNickname(chatMessage.sender());
-        Message message = chatMessage.toEntity(sender);
+        ChatRoom chatRoom = chatRoomService.findChatRoomById(chatRoomId);
+        Message message = chatMessage.toEntity(sender, chatRoom);
         messageService.saveMessage(message);
         messagingTemplate.convertAndSend("/topic/chatroom/" + chatRoomId, chatMessage);
     }

--- a/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/impl/MessageServcieImpl.java
+++ b/explorer-external-api/src/main/java/com/CPGroupH/domains/chat/service/impl/MessageServcieImpl.java
@@ -4,6 +4,8 @@ import com.CPGroupH.domains.chat.entity.Message;
 import com.CPGroupH.domains.chat.entity.repository.MessageRepository;
 import com.CPGroupH.domains.chat.service.MessageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,4 +17,9 @@ public class MessageServcieImpl implements MessageService {
     public Message saveMessage(Message message) {
         return messageRepository.save(message);
     }
+
+    public Page<Message> getMessagesByChatRoomId(Long chatRoomId, Pageable pageable) {
+        return messageRepository.findByChatRoomId(chatRoomId, pageable);
+    }
+
 }


### PR DESCRIPTION
## 작업 내용
1. 채팅방 조회 기능 추가
2. 메세지 조회 기능 추가

### 1. 작업 설명
채팅방 조회 기능 추가: 쿼리 파라미터를 통해 참가자ID, limit, sort, order 를 받고 클라이언트에서 보낸 값에 따라서 필터링 되어 page로 반환
메세지 조회 기능 추가: 쿼리 파라미터를 통해 채팅방ID, page, limit, sort, order 를 받고 클라이언트에서 보낸 값에 따라서 필터링 되어 page로 반환

### 다음 진행할 내용
채팅방 insert, delete


